### PR TITLE
Upgrade the metrics to latest version 3.0.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,14 +19,22 @@
     </developers>
 
     <repositories>
+	    <repository>
+             <id>ds-master</id>
+             <url>http://nexus.ds.chalybs.net/content/groups/master</url>
+        </repository>
         <repository>
+		    <id>repo.codahale.com</id>
+		    <url>http://repo.codahale.com</url>
+		  </repository>
+        <!--repository>
             <id>scala-tools-releases</id>
-            <url>http://scala-tools.org/repo-releases/</url>
+            <url>http://scala-tools.org/repo-releases</url>
         </repository>
         <repository>
             <id>repo.codahale.com</id>
             <url>http://repo.codahale.com</url>
-        </repository>
+        </repository-->
         <repository>
             <id>jboss</id>
             <url>https://repository.jboss.org/nexus/content/repositories/releases</url>
@@ -34,6 +42,10 @@
     </repositories>
 
     <pluginRepositories>
+	    <pluginRepository>
+                <id>ds-master</id>
+                <url>http://nexus.ds.chalybs.net/content/groups/master</url>
+        </pluginRepository>
         <pluginRepository>
             <id>scala-tools-releases</id>
             <url>http://scala-tools.org/repo-releases/</url>
@@ -49,17 +61,17 @@
         <dependency>
             <groupId>com.yammer.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>2.0.3</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.yammer.metrics</groupId>
             <artifactId>metrics-graphite</artifactId>
-            <version>2.0.3</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.yammer.metrics</groupId>
             <artifactId>metrics-scala_${scala.version}</artifactId>
-            <version>2.0.3</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/src/main/scala/net/mojodna/metricsd/server/MetricsServiceHandler.scala
+++ b/src/main/scala/net/mojodna/metricsd/server/MetricsServiceHandler.scala
@@ -83,9 +83,11 @@ class MetricsServiceHandler
             case GAUGE_METRIC_TYPE =>
               log.debug("Updating gauge '%s' with %d", metricName, value)
               // use a counter to simulate a gauge
-              val counter = Metrics.newCounter(new MetricName("metrics", "gauge", metricName))
-              counter.clear()
-              counter.inc(value)
+              //val counter = Metrics.newCounter(new MetricName("metrics", "gauge", metricName))
+              //counter.clear()
+              //counter.inc(value)
+			 // Change it to use the Metrics.newGauge API. By Yongjun Rong
+			 Metrics.newGauge(new MetricName("metrics", "gauge", metricName),value);
 
             case HISTOGRAM_METRIC_TYPE | TIMER_METRIC_TYPE =>
               log.debug("Updating histogram '%s' with %d", metricName, value)


### PR DESCRIPTION
Hey,
   I upgraded it to use the latest metrics version 3.0.0-SNAPSHOT. It allow me to use the newGauge api for gaue without using counter to simulate it.
  If you have any questions, please let me know.
  Thanks
  Yongjun Rong
