### PR TITLE
Use Timer metric for timers so we get rate meters as well. Also, allow <hostname> as a special case prefix

### DIFF
--- a/config/metricsd.json
+++ b/config/metricsd.json
@@ -3,14 +3,14 @@
     "debug": false,
     "graphite": {
         "flushInterval": 10,
-        "host": "localhost",
+        "host": "metrics.prod.cheggnet.com",
         "port": 2003
     },
     "log": {
         "level": "INFO",
-        "file": "log/metricsd.log"
+        "file": "/logs/metricsd.log"
     },
     "port": 8125,
-    "prefix": "metricsd",
+    "prefix": "<hostname>",
     "managementPort": 8126
 }

--- a/src/main/scala/net/mojodna/metricsd/server/ManagementServiceHandler.scala
+++ b/src/main/scala/net/mojodna/metricsd/server/ManagementServiceHandler.scala
@@ -13,6 +13,7 @@ class ManagementServiceHandler
   val COUNTERS = "counters"
   val GAUGES = "gauges"
   val HISTOGRAMS = "histograms"
+  val TIMERS = "timers"
   val METERS = "meters"
   val QUIT = "quit"
 
@@ -23,7 +24,7 @@ class ManagementServiceHandler
 
     msg match {
       case HELP =>
-        e.getChannel.write("COMMANDS: counters, gauges, histograms, meters, quit\n\n")
+        e.getChannel.write("COMMANDS: counters, gauges, histograms, timers, meters, quit\n\n")
       case COUNTERS =>
         for((metricName, metric) <- Metrics.defaultRegistry.allMetrics if metricName.getType == "counter") e.getChannel.write(metricName.getName + "\n")
         e.getChannel.write("END\n\n")
@@ -32,6 +33,9 @@ class ManagementServiceHandler
         e.getChannel.write("END\n\n")
       case HISTOGRAMS =>
         for((metricName, metric) <- Metrics.defaultRegistry.allMetrics if metricName.getType == "histogram") e.getChannel.write(metricName.getName + "\n")
+        e.getChannel.write("END\n\n")
+      case TIMERS =>
+        for((metricName, metric) <- Metrics.defaultRegistry.allMetrics if metricName.getType == "timer") e.getChannel.write(metricName.getName + "\n")
         e.getChannel.write("END\n\n")
       case METERS =>
         for((metricName, metric) <- Metrics.defaultRegistry.allMetrics if metricName.getType == "meter") e.getChannel.write(metricName.getName + "\n")

--- a/src/main/scala/net/mojodna/metricsd/server/MetricsServiceHandler.scala
+++ b/src/main/scala/net/mojodna/metricsd/server/MetricsServiceHandler.scala
@@ -14,7 +14,7 @@ import java.net.UnknownHostException
 /**
  * A service handler for :-delimited metrics strings (à la Etsy's statsd).
  */
-class MetricsServiceHandler(prefix: String)
+class MetricsServiceHandler(configPrefix: String)
   extends SimpleChannelUpstreamHandler with Logging {
 
   val COUNTER_METRIC_TYPE = "c"
@@ -25,7 +25,11 @@ class MetricsServiceHandler(prefix: String)
   val TIMER_METRIC_TYPE = "ms"
 
   val MetricMatcher = new Regex("""([^:]+)(:((-?\d+|delete)?(\|((\w+)(\|@(\d+\.\d+))?)?)?)?)?""")
-  var  hostValue="UNKNOWN"
+  var prefix ="metricsd"
+
+  if (configPrefix.equals("<hostname>"))
+  {
+        var  hostValue="UNKNOWN"
  		try
  		{
  			val addr = InetAddress.getLocalHost()
@@ -43,12 +47,18 @@ class MetricsServiceHandler(prefix: String)
  			{
  				hostValue = hostpath( 0 )
  			}
+ 			prefix=hostValue
  		}
  		catch
  		{
  		    case ukh: UnknownHostException =>
  		        log.trace("couldn't find host",ukh)
  		}
+ 	}
+ 	else
+ 	{
+ 	    prefix=configPrefix
+ 	}
 
   override def messageReceived(ctx: ChannelHandlerContext, e: MessageEvent) {
     val msg = e.getMessage.asInstanceOf[String]

--- a/src/main/scala/net/mojodna/metricsd/server/MetricsServiceHandler.scala
+++ b/src/main/scala/net/mojodna/metricsd/server/MetricsServiceHandler.scala
@@ -103,13 +103,13 @@ class MetricsServiceHandler(configPrefix: String)
             case GAUGE_METRIC_TYPE =>
               new MetricName("metrics", "gauge", metricName)
 
-            case HISTOGRAM_METRIC_TYPE | TIMER_METRIC_TYPE =>
+            case HISTOGRAM_METRIC_TYPE  =>
               new MetricName("metrics", "histogram", metricName)
 
-            case METER_METRIC_TYPE | METER_VALUE_METRIC_TYPE =>
-              new MetricName("metrics", "meter", metricName)
+            case TIMER_METRIC_TYPE =>
+              new MetricName("metrics", "timer", metricName)
 
-            case METER_VALUE_METRIC_TYPE =>
+            case METER_METRIC_TYPE | METER_VALUE_METRIC_TYPE =>
               new MetricName("metrics", "meter", metricName)
           }
 
@@ -128,10 +128,15 @@ class MetricsServiceHandler(configPrefix: String)
               counter.clear()
               counter.inc(value)
 
-            case HISTOGRAM_METRIC_TYPE | TIMER_METRIC_TYPE =>
+            case HISTOGRAM_METRIC_TYPE  =>
               log.debug("Updating histogram '%s' with %d", metricName, value)
               // note: assumes that values have been normalized to integers
               Metrics.newHistogram(new MetricName("metrics", "histogram", metricName), true).update(value)
+
+            case TIMER_METRIC_TYPE =>
+              log.debug("Updating timer '%s' with %d", metricName, value)
+              // note: assumes that values have been normalized to integers & milliseconds
+              Metrics.newTimer(new MetricName("metrics", "timer", metricName), TimeUnit.MILLISECONDS, TimeUnit.SECONDS).update(value,TimeUnit.MILLISECONDS)
 
             case METER_METRIC_TYPE =>
               log.debug("Marking meter '%s'", metricName)


### PR DESCRIPTION
This separates out the timer metrics into their own category, because codahale metrics collects timers as both a histogram on the time and a meter on the rate. 

If the prefix is set to <hostname> the metricsd statistics will be prefixed by the first two words of the FQDN of the hostname. At chegg, that's <hostname>.<environment>.
